### PR TITLE
Add performance benchmark script.

### DIFF
--- a/test/performance/Manifest.toml
+++ b/test/performance/Manifest.toml
@@ -1,0 +1,187 @@
+[[ArnoldiMethod]]
+deps = ["DelimitedFiles", "LinearAlgebra", "Pkg", "Random", "SparseArrays", "StaticArrays", "Test"]
+git-tree-sha1 = "2b6845cea546604fb4dca4e31414a6a59d39ddcd"
+uuid = "ec485272-7323-5ecc-a04f-4719b315124d"
+version = "0.0.4"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BenchmarkTools]]
+deps = ["JSON", "Pkg", "Printf", "Statistics", "Test"]
+git-tree-sha1 = "e686f1754227e4748259f400839b83a1e8773e02"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "0.4.1"
+
+[[BinaryProvider]]
+deps = ["Libdl", "Pkg", "SHA", "Test"]
+git-tree-sha1 = "48c147e63431adbcee69bc40b04c3f0fec0a4982"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.5.0"
+
+[[CodecZlib]]
+deps = ["BinaryProvider", "Libdl", "Pkg", "Test", "TranscodingStreams"]
+git-tree-sha1 = "83cb3d65c37ea1364c2d5bf7bcea41843ba645dc"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.5.0"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "ff2595695fc4f14427358ce2593f867085c45dcb"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "1.2.0"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "OrderedCollections", "REPL", "Random", "Serialization", "Test"]
+git-tree-sha1 = "8fc6e166e24fda04b2b648d4260cdad241788c54"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.14.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Inflate]]
+path = "../.."
+uuid = "5759bcd8-b781-11e8-19cb-9f31d28d2f91"
+version = "0.1.0"
+
+[[InteractiveUtils]]
+deps = ["LinearAlgebra", "Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Distributed", "Mmap", "Pkg", "Sockets", "Test", "Unicode"]
+git-tree-sha1 = "fec8e4d433072731466d37ed0061b3ba7f70eeb9"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.19.0"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LightGraphs]]
+deps = ["ArnoldiMethod", "Base64", "CodecZlib", "DataStructures", "DelimitedFiles", "Distributed", "LinearAlgebra", "Markdown", "Pkg", "Random", "SharedArrays", "SimpleTraits", "SparseArrays", "Statistics", "Test"]
+git-tree-sha1 = "446a9cf208ec401ae67e517de4eeceaf2cd5cdac"
+uuid = "093fc24a-ae57-5d10-9952-331d41423f4d"
+version = "1.1.0"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[MacroTools]]
+deps = ["Compat"]
+git-tree-sha1 = "c443e1c8d58a4e9f61b708ad0a88286c7042145b"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.4.4"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Missings]]
+deps = ["Dates", "InteractiveUtils", "SparseArrays", "Test"]
+git-tree-sha1 = "adc26d2ee85a49c413464110d922cf21efc9d233"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "0.3.1"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[OrderedCollections]]
+deps = ["Pkg", "Random", "Serialization", "Test"]
+git-tree-sha1 = "85619a3f3e17bb4761fe1b1fd47f0e979f964d5b"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.0.2"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[SimpleTraits]]
+deps = ["InteractiveUtils", "MacroTools", "Pkg", "Test"]
+git-tree-sha1 = "c0a542b8d5e369b179ccd296b2ca987f6da5da0a"
+uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+version = "0.8.0"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SortingAlgorithms]]
+deps = ["DataStructures", "Random", "Test"]
+git-tree-sha1 = "03f5898c9959f8115e30bc7226ada7d0df554ddd"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "0.3.1"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[StaticArrays]]
+deps = ["InteractiveUtils", "LinearAlgebra", "Random", "Statistics", "Test"]
+git-tree-sha1 = "d432c79bef174a830304f8601427a4357dfdbfb7"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "0.8.3"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[StatsBase]]
+deps = ["DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "Test"]
+git-tree-sha1 = "723193a13e8078cec6dcd0b8fe245c8bfd81690e"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.25.0"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TranscodingStreams]]
+deps = ["DelimitedFiles", "Pkg", "Random", "Test"]
+git-tree-sha1 = "a34a2d588e2d2825602bf14a24216d5c8b0921ec"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.8.1"
+
+[[UUIDs]]
+deps = ["Random"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/test/performance/Project.toml
+++ b/test/performance/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+Inflate = "5759bcd8-b781-11e8-19cb-9f31d28d2f91"
+LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"

--- a/test/performance/test_performance.jl
+++ b/test/performance/test_performance.jl
@@ -1,0 +1,144 @@
+using Pkg
+Pkg.activate(@__DIR__)
+Pkg.instantiate()
+
+using Inflate
+using BenchmarkTools
+using CodecZlib
+using LightGraphs
+using StatsBase
+using Random
+using Printf
+
+# Generate an incompressible vector of length `n`.
+incompressible(n) = rand(UInt8, n)
+
+# Generate a Huffman compressible vector of length `n`.
+function huffman_compressible(n)
+    w = 0.844 .^ (0:255)
+    return sample(StatsBase.shuffle(UInt8.(0:255)), Weights(w), n)
+end
+
+# Generate a runlength compressible vector of length `n`.
+function runlength(n)
+    x = UInt8[]
+    while length(x) < n
+        m = min(sample(1:32), n - length(x))
+        append!(x, fill(rand(UInt8), m))
+    end
+    return x
+end
+
+# Generate a LightGraphs save file of length approximately `n`.
+# Note: the balance between nodes and edges needs to be adjusted for
+# savefiles smaller than about 620 bytes.
+function graph(n)
+    buf = IOBuffer()
+    m = ceil(Int, n / (2 * (log10(n) - 1)))
+    local x
+    for k = 1:4
+        g = erdos_renyi(m ÷ 10, m, is_directed = true)
+        savegraph(buf, g, "", LGFormat())
+        x = take!(buf)
+        m = m * n ÷ length(x)
+    end
+    return x
+end
+
+sizes = Dict(:small => 1_000, :medium => 100_000, :large => 10_000_000)
+generators = Dict(:incompressible => incompressible,
+                  :huffman => huffman_compressible,
+                  :runlength => runlength,
+                  :graph => graph)
+compressors = Dict(:deflate => DeflateCompressor,
+                   :zlib => ZlibCompressor,
+                   :gzip => GzipCompressor)
+zlib_decompressors = Dict(:deflate => DeflateDecompressor,
+                          :zlib => ZlibDecompressor,
+                          :gzip => GzipDecompressor)
+inflate_decompressors = Dict(:deflate => inflate,
+                             :zlib => inflate_zlib,
+                             :gzip => inflate_gzip)
+zlib_decompressor_streams = Dict(:deflate => DeflateDecompressorStream,
+                                 :zlib => ZlibDecompressorStream,
+                                 :gzip => GzipDecompressorStream)
+inflate_decompressor_streams = Dict(:deflate => InflateStream,
+                                    :zlib => InflateZlibStream,
+                                    :gzip => InflateGzipStream)
+
+function run_tests()
+    results = Dict{Any, Float64}()
+    for data_size in keys(sizes)
+        for data_type in keys(generators)
+            Random.seed!(13)
+            x = generators[data_type](sizes[data_size])
+            for format in keys(compressors)
+                compressed = transcode(compressors[format], x)
+                zlib_decompressor = zlib_decompressors[format]
+                inflate_decompressor = inflate_decompressors[format]
+                GC.gc()
+                t1 = @belapsed transcode($zlib_decompressor, $compressed)
+                GC.gc()
+                t2 = @belapsed $inflate_decompressor($compressed)
+                results[(data_size, data_type, format, :zlib, :in_memory)] = t1
+                results[(data_size, data_type, format, :inflate, :in_memory)] = t2
+                zlib_decompressor_stream = zlib_decompressor_streams[format]
+                inflate_decompressor_stream = inflate_decompressor_streams[format]
+                GC.gc()
+                t3 = @belapsed read($zlib_decompressor_stream(stream)) setup=(stream = IOBuffer($compressed)) evals=1
+                GC.gc()
+                t4 = @belapsed read($inflate_decompressor_stream(stream)) setup=(stream = IOBuffer($compressed)) evals=1
+                results[(data_size, data_type, format, :zlib, :streaming)] = t3
+                results[(data_size, data_type, format, :inflate, :streaming)] = t4
+            end
+        end
+    end
+    return results
+end
+
+function print_results(results, mode)
+    mode_string = replace(string(mode), "_" => " ")
+    println("Results for $(mode_string):")
+    for data_type in [:incompressible, :huffman, :runlength, :graph]
+        for data_size in [:small, :medium, :large]
+            for format in [:deflate, :zlib, :gzip]
+                t1 = results[(data_size, data_type, format, :zlib, mode)]
+                t2 = results[(data_size, data_type, format, :inflate, mode)]
+                @printf("%6s %14s %7s: %4.1f %8.1f %8.1f \n",
+                        data_size, data_type, format, t2 / t1, 1e6*t1, 1e6*t2)
+            end
+        end
+    end
+end
+
+function print_markdown_row(row)
+    println(join(vcat("", row, ""), " | "))
+end
+
+function print_markdown_table(results, mode)
+    mode_string = Dict(:in_memory => "In Memory", :streaming => "Streaming")[mode]
+    data_types = [:incompressible, :huffman, :runlength, :graph]
+    # TODO: Retrieve the version number from Pkg.
+    print_markdown_row(vcat("v0.1.0", mode_string, fill("", 4)))
+    print_markdown_row(fill("-", 6))
+    print_markdown_row(vcat("", "", string.(data_types)))
+    for data_size in [:small, :medium, :large]
+        row = [string(data_size)]
+        for format in [:deflate, :zlib, :gzip]
+            push!(row, string(format))
+            for data_type in data_types
+                t1 = results[(data_size, data_type, format, :zlib, mode)]
+                t2 = results[(data_size, data_type, format, :inflate, mode)]
+                push!(row, @sprintf("%4.1f", t2 / t1))
+            end
+            print_markdown_row(row)
+            row = [""]
+        end
+    end
+end
+
+results = run_tests()
+print_results(results, :in_memory)
+print_results(results, :streaming)
+print_markdown_table(results, :in_memory)
+print_markdown_table(results, :streaming)


### PR DESCRIPTION
This PR adds a performance benchmark script measuring the speed of Inflate compared to CodecZlib. This is done for three different sizes, four different types of data, the three supported formats (Deflate, Zlib, Gzip), and both in memory and streaming operation.

To run the script from a shell, `cd` to the Inflate package and do
```
julia test/performance/test_performance.jl`
```
To run from Julia (note: this will change your Pkg environment):
```
using Inflate
include(joinpath(dirname(dirname(pathof(Inflate))),
        "test", "performance", "test_performance.jl"))
```
The result are printed lists of the detailed results and markdown tables with ratios between time for Inflate and time for CodecZlib. When running from Julia, the raw measurement data is also available in the `results` variable upon finishing.
