### PR TITLE
Avoid aliased copyto! by not calling copyto.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Inflate"
 uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
 authors = ["Gunnar Farnebäck <gunnar@lysator.liu.se>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [compat]
 CodecZlib = "0.5, 0.6, 0.7"

--- a/src/Inflate.jl
+++ b/src/Inflate.jl
@@ -761,9 +761,10 @@ function write_to_buffer(data::StreamingInflateData, x::UInt8)
 end
 
 function write_to_buffer(data::StreamingInflateData, x::AbstractVector{UInt8})
-    n = length(x)
-    copyto!(data.output_buffer, data.write_pos, x, 1, n)
-    data.write_pos += n
+    for i in eachindex(x)
+        data.output_buffer[data.write_pos + i - 1] = x[i]
+    end
+    data.write_pos += length(x)
     if data.write_pos > buffer_size
         data.write_pos -= buffer_size
     end
@@ -829,9 +830,6 @@ function getbyte(stream::AbstractInflateStream)
             if pos <= 0
                 n = min(n, 1 - pos)
                 pos += buffer_size
-            else
-                # Needed to avoid aliased `copyto!`.
-                n = min(n, stream.data.distance)
             end
             stream.data.pending_bytes -= n
             write_to_buffer(stream, @view stream.data.output_buffer[pos:(pos + n - 1)])


### PR DESCRIPTION
The fix for aliased `copyto!` in #11 didn't solve the problem that `copyto!` for `SubArray` still allocated and was kind of slow. This PR instead solves the aliasing problem by replacing the `copyto!` with a plain loop, which ensures the intended aliasing behavior.

Cf. https://github.com/tlnagy/TiffImages.jl/issues/115 where the allocation problem was observed.