### PR TITLE
Remove unnecessary unaliasing allocation

### DIFF
--- a/src/Inflate.jl
+++ b/src/Inflate.jl
@@ -255,7 +255,9 @@ function _inflate(data::InflateData)
                 length = getlength(data, v)
                 distance = getdist(data)
                 if length <= distance
-                    append!(out, @view out[(end - distance + 1):(end - distance + length)])
+                    ln = Base.length(out)
+                    resize!(out, ln+length)
+                    copyto!(out, ln+1, out, ln-distance+1, length)
                 else
                     for i = 1:length
                         push!(out, out[end - distance + 1])


### PR DESCRIPTION
Profiling reveals that this `append!` call allocates. Benchmarking reveals that changing the implementation speeds things up. Hopefully future versions of Julia will be clever enough to determine that there is no aliasing in the `append!` case but on Julia 1.10.5 `append!` makes a copy to prevent possible aliasing.

 | PR | In Memory |  |  |  |  | 
 | - | - | - | - | - | - | 
 |  |  | incompressible | huffman | runlength | graph | 
 | small | deflate |  2.0 |  2.9 |  4.0 |  2.4 | 
 |  | zlib |  2.7 |  2.9 |  3.9 |  2.5 | 
 |  | gzip |  3.9 |  3.0 |  3.4 |  2.6 | 
 | medium | deflate |  1.5 |  3.3 |  2.6 |  3.1 | 
 |  | zlib |  3.6 |  3.5 |  2.8 |  3.2 | 
 |  | gzip |  5.0 |  3.5 |  3.5 |  3.4 | 
 | large | deflate |  3.5 |  3.5 |  2.6 |  3.3 | 
 |  | zlib |  4.1 |  3.5 |  2.8 |  3.3 | 
 |  | gzip |  5.2 |  3.6 |  3.2 |  3.6 | 

  | master | In Memory |  |  |  |  | 
 | - | - | - | - | - | - | 
 |  |  | incompressible | huffman | runlength | graph | 
 | small | deflate |  2.1 |  3.4 |  3.9 |  3.5 | 
 |  | zlib |  2.8 |  3.5 |  3.9 |  3.6 | 
 |  | gzip |  4.2 |  3.6 |  3.5 |  3.5 | 
 | medium | deflate |  1.6 |  4.4 |  3.8 |  5.1 | 
 |  | zlib |  3.5 |  4.5 |  4.0 |  4.8 | 
 |  | gzip |  4.9 |  4.9 |  3.9 |  4.8 | 
 | large | deflate |  3.5 |  4.7 |  3.8 |  7.0 | 
 |  | zlib |  4.0 |  4.6 |  3.8 |  5.1 | 
 |  | gzip |  5.4 |  4.7 |  4.3 |  5.2 | 

This is a big improvement for the large deflate graph case!

```julia-repl
julia> @b compressed inflate
129.791 ms (1605215 allocs: 118.158 MiB, 2.13% gc time)

shell> git checkout lh/perf-alloc-1
Previous HEAD position was cc77be7 Fix correctness for 32-bit Julia.
Switched to branch 'lh/perf-alloc-1'
Your branch is up to date with 'origin/lh/perf-alloc-1'.

julia> @b compressed inflate
81.500 ms (8300 allocs: 20.690 MiB)
```