### PR TITLE
Reduce allocations and branching in transform_code_lengths_to_code

### DIFF
--- a/src/Inflate.jl
+++ b/src/Inflate.jl
@@ -172,13 +172,10 @@ function getdist(data::AbstractInflateData)
 end
 
 function transform_code_lengths_to_code(code_lengths::Vector{Int})
-    code = Vector{Int}[]
+    code = [Int[] for _ in 1:maximum(code_lengths)]
     for i = 1:length(code_lengths)
         n = code_lengths[i]
         if n > 0
-            while n > length(code)
-                push!(code, Int[])
-            end
             push!(code[n], i - 1)
         end
     end


### PR DESCRIPTION
This is a small performance improvement. It is not visible when running end to end benchmarks (nor is there a visible regression). We can see an improvement when just benchmarking the target function, though:

```julia-repl
julia> Random.seed!(13); for i in 1:10
           x = rand(1:i, rand(1:i))
           display(@b x Inflate.transform_code_lengths_to_code)
       end
61.461 ns (4 allocs: 272 bytes)
98.814 ns (6 allocs: 416 bytes)
137.207 ns (8 allocs: 560 bytes)
105.065 ns (6 allocs: 400 bytes)
191.794 ns (11 allocs: 768 bytes)
207.341 ns (11 allocs: 768 bytes)
164.368 ns (9 allocs: 592 bytes)
261.114 ns (14 allocs: 960 bytes)
295.660 ns (16 allocs: 1.328 KiB)
304.303 ns (16 allocs: 1.094 KiB)

shell> git stash pop
...

julia> Random.seed!(13); for i in 1:10
           x = rand(1:i, rand(1:i))
           display(@b x Inflate.transform_code_lengths_to_code)
       end
46.199 ns (3 allocs: 208 bytes)
81.508 ns (5 allocs: 352 bytes)
113.339 ns (7 allocs: 512 bytes)
86.581 ns (5 allocs: 352 bytes)
163.136 ns (10 allocs: 736 bytes)
171.270 ns (10 allocs: 736 bytes)
131.980 ns (8 allocs: 560 bytes)
220.342 ns (13 allocs: 944 bytes)
223.109 ns (14 allocs: 1.000 KiB)
254.167 ns (15 allocs: 1.078 KiB)
```
Looping through the input a second time is cheap compared to the additional branching and allocations within the loop. IMO this is also slightly simpler to understand, though the previous version was also quite legible.